### PR TITLE
Fix missing header files on UOS (Also other Linux based OS)

### DIFF
--- a/llvm/lib/Transforms/Obfuscation/CryptoUtils.cpp
+++ b/llvm/lib/Transforms/Obfuscation/CryptoUtils.cpp
@@ -34,6 +34,9 @@
 #include <random>
 #include <chrono>
 #endif
+#if defined(__linux__)
+#include <fstream>
+#endif
 
 // Stats
 #define DEBUG_TYPE "CryptoUtils"


### PR DESCRIPTION
The random value generation on UOS (统信操作系统) acquires an extra header file, or the build progress will be failed.