### PR TITLE
Fix llvm build error on msys2 x86_64-pc-windows-gnu

### DIFF
--- a/llvm/tools/bugpoint/CMakeLists.txt
+++ b/llvm/tools/bugpoint/CMakeLists.txt
@@ -21,6 +21,7 @@ set(LLVM_LINK_COMPONENTS
   TargetParser
   TransformUtils
   Vectorize
+  Obfuscation
   )
 
 add_llvm_tool(bugpoint


### PR DESCRIPTION
I'm not that used to LLVM infrastructure, but while building, I got this error.
Maybe `llvm/tools/bugpoint`'s `CMakeLists.txt` is not updated to include the `Obfuscation` module.

/path/to/x86_64-w64-mingw32/bin/ld.exe: lib/libLLVMObfuscation.a(StringEncryption.cpp.obj):StringEncryption.cpp:(.text$_ZN12_GLOBAL__N_116StringEncryption11runOnModuleERN4llvm6ModuleE+0x131a): undefined reference to `llvm::isSafeToDestroyConstant(llvm::Constant const*)'