### PR TITLE
Fix: UTF-16 alignment, minor memory leak and control flow edge case 

### DIFF
--- a/llvm/lib/Transforms/Obfuscation/StringEncryption.cpp
+++ b/llvm/lib/Transforms/Obfuscation/StringEncryption.cpp
@@ -237,6 +237,12 @@ bool StringEncryption::runOnModule(Module &M) {
     JunkBytes.clear();
     getRandomBytes(JunkBytes, 16, 32);
     Data.insert(Data.end(), JunkBytes.begin(), JunkBytes.end());
+
+    // For UTF-16: ensure 2-byte alignment to avoid misaligned i16 loads
+    if (Entry->IsUTF16 && (Data.size() % 2) != 0) {
+      Data.push_back(0);
+    }
+
     Entry->Offset = static_cast<unsigned>(Data.size());
     if (!Entry->IsUTF16) {
       Data.insert(Data.end(), Entry->EncKey.begin(), Entry->EncKey.end());


### PR DESCRIPTION
Fixed a possible crash on ARM (or any alignment-sensitive architecture) where UTF-16 encrypted strings could have odd-length offsets (16-31), causing misaligned i16 loads.

I've also fixed a memory leak in the flattening pass where the lower switch pass wasn't freed on any early returned (now a `std::unique_ptr`). 

In the flattening, I've changed the fallback case from the last case to case 0 when a branch target isn't in the switch. Before, it used `getNumCases() - 1` (last case) as fallback, but case 0 is `bbEndOfEntry` - which is the closest semantic match. This case is still probably super rare anyways but going to `bbEndOfEntry` makes more sense than any last case.

I've tested these changes with a sample project, everything works fine.
Also, great project - was upset when I saw it vanish randomly. 