### PR TITLE
[docs] 修复 README 中 Linux 构建指令的拼写错误并优化格式

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,26 @@ ninja install
 ```
 mkdir build
 cd build
-cmake -G Ninja   -DCMAKE_BUILD_TYPE=Release   -DCMAKE_INSTALL_PREFIX="./install"   -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld;lldb"   -DLLVM_TARGETS_TO_BUILD="X86"   -DLLVM_ENABLE_RUNTIMES="compiler-rt;openmp"   -DCOMPILER_RT_BUILD_ORC=OFF   -DLLVM_BUILD_LLVM_C_DYLIB=OFF   -DLLVM_BUILD_TOOLS=ON   -DLLVM_INCLUDE_TESTS=OFF   -DLLVM_INCLUDE_EXAMPLES=OFF   -DLLVM_INCLUDE_BENCHMARKS=OFF   -DLLVM_ENABLE_ASSERTIONS=OFF   -DLLVM_RELEASE_ENABLE_LTO=OFF   -DLLVM_RELEASE_ENABLE_PGO=OFF -DLLVM_ENABLE_PIC=ON  ../llvm
-ninja j8
+cmake -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="./install" \
+    -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lld;lldb" \
+    -DLLVM_TARGETS_TO_BUILD="X86" \
+    -DLLVM_ENABLE_RUNTIMES="compiler-rt;openmp" \
+    -DCOMPILER_RT_BUILD_ORC=OFF \
+    -DLLVM_BUILD_LLVM_C_DYLIB=OFF \
+    -DLLVM_BUILD_TOOLS=ON \
+    -DLLVM_INCLUDE_TESTS=OFF \
+    -DLLVM_INCLUDE_EXAMPLES=OFF \
+    -DLLVM_INCLUDE_BENCHMARKS=OFF \
+    -DLLVM_ENABLE_ASSERTIONS=OFF \
+    -DLLVM_RELEASE_ENABLE_LTO=OFF \
+    -DLLVM_RELEASE_ENABLE_PGO=OFF \
+    -DLLVM_ENABLE_PIC=ON \
+    ../llvm
+
+ninja -j8
+ninja install
 ```
 ## 编译时失败怎么办
 ninja 和 makefile 可以添加 -k 参数，部分文件失败不影响整个clang的使用。


### PR DESCRIPTION
## Summary
- 修复拼写错误：`ninja j8` → `ninja -j8`
- 格式化 cmake 参数，每行一个，与其他平台（macOS、Windows）保持一致
- 末尾补充 `ninja install`，与其他平台一致

## Test plan
- 仅文档修改，无需测试。